### PR TITLE
restyled checkbox component, added labelBefore variant

### DIFF
--- a/client/src/components/Checkbox.css
+++ b/client/src/components/Checkbox.css
@@ -25,9 +25,20 @@
   margin-right: 12px;
 }
 
+.checkbox__label {
+  margin-inline-start: auto;
+  margin-right: 14px;
+
+}
+
 .checkbox--label-before .checkbox__overlay {
   margin-right: 0;
   margin-left: 12px;
+}
+.checkbox--label-before .checkbox__label {
+  margin-inline-end: auto;
+  margin-left: 14px;
+  margin-right: 0px;
 }
 
 .checkbox__check {

--- a/client/src/components/Checkbox.css
+++ b/client/src/components/Checkbox.css
@@ -1,7 +1,10 @@
 .checkbox {
   display: flex;
   align-items: center;
-  cursor: pointer;
+}
+
+.checkbox--label-before {
+  flex-direction: row-reverse;
 }
 
 .checkbox * {
@@ -9,12 +12,35 @@
 }
 
 .checkbox__input {
-  cursor: pointer;
-  max-width: 24rem;
-  border-width: 2px;
-  border-style: solid;
+  position: absolute;
+  opacity: 0;
+}
+.checkbox__overlay {
+  position: relative;
+  background-color: white;
   border-radius: 4px;
-  height: 16px;
-  width: 16px;
-  margin-right: 8px;
+  width: 48px;
+  height: 48px;
+  border: 2px solid #bdbdbd;
+  margin-right: 12px;
+}
+
+.checkbox--label-before .checkbox__overlay {
+  margin-right: 0;
+  margin-left: 12px;
+}
+
+.checkbox__check {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #2d9cdb;
+  display: none;
+  font-weight: 500;
+  font-size: 45px;
+}
+
+.checkbox__input:checked ~ .checkbox__overlay .checkbox__check {
+  display: block;
 }

--- a/client/src/components/Checkbox.jsx
+++ b/client/src/components/Checkbox.jsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./Checkbox.css";
 
 function Checkbox({ label, checked, value, onChange, labelBefore }) {
-  const [isChecked, setChecked] = useState(checked ? checked : false);
+  const [isChecked, setChecked] = useState(!!checked);
   const handleChange = () => {
     const checkedState = !isChecked;
     setChecked(checkedState);
@@ -24,7 +24,7 @@ function Checkbox({ label, checked, value, onChange, labelBefore }) {
       <div className="checkbox__overlay">
         <span className="checkbox__check">&#10003;</span>
       </div>
-      <label htmlFor={`${label}-checkbox`}>{label}</label>
+      <label className="checkbox__label" htmlFor={`${label}-checkbox`}>{label}</label>
     </span>
   );
 }

--- a/client/src/components/Checkbox.jsx
+++ b/client/src/components/Checkbox.jsx
@@ -1,19 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 import "./Checkbox.css";
 
-function Checkbox({ label, checked, value, onChange }) {
-  const handleChange = () => onChange(!checked);
-
+function Checkbox({ label, checked, value, onChange, labelBefore }) {
+  const [isChecked, setChecked] = useState(checked ? checked : false);
+  const handleChange = () => {
+    const checkedState = !isChecked;
+    setChecked(checkedState);
+    onChange(checkedState);
+  };
+  const baseClass = "checkbox";
+  const wrapperClass = labelBefore
+    ? `${baseClass} ${baseClass}--label-before`
+    : baseClass;
   return (
-    <span className="checkbox" onClick={handleChange}>
+    <span className={wrapperClass} onClick={handleChange}>
       <input
         className="checkbox__input"
         type="checkbox"
         name={`${label}-checkbox`}
         value={value}
-        checked={checked}
-        onChange={handleChange}
+        checked={isChecked}
       />
+      <div className="checkbox__overlay">
+        <span className="checkbox__check">&#10003;</span>
+      </div>
       <label htmlFor={`${label}-checkbox`}>{label}</label>
     </span>
   );


### PR DESCRIPTION
checkbox component has been restyled. component was somewhat refactored as it had been changing it's props rather than managing it's own state. additionally, a prop called labelBefore allows for a rendering with the label on the left or right.

I'm aware that this many changes in one commit is considered bad form. 