### PR TITLE
no longer offer renaming on play again

### DIFF
--- a/client/src/components/TeamBox.jsx
+++ b/client/src/components/TeamBox.jsx
@@ -3,6 +3,7 @@ import "./TeamBox.css";
 import { Button } from "./index";
 
 const TeamBox = ({
+  isGameOver,
   className,
   teamName,
   children,
@@ -29,7 +30,7 @@ const TeamBox = ({
         >
           {teamName}
         </div>
-        {myTeam && !myTurn && (
+        {myTeam && !myTurn && !isGameOver && (
           <Button
             onClick={onRenameClick}
             type="secondary"

--- a/client/src/views/Party/GamePlay.jsx
+++ b/client/src/views/Party/GamePlay.jsx
@@ -297,6 +297,7 @@ function GamePlay({ party, username, onPoint, pointedAt }) {
             )}
             {teams.map((team, index) => (
               <TeamBox
+                isGameOver={isGameOver}
                 key={team.teamName}
                 myTeam={team.teamPlayers.includes(username)}
                 myTurn={actorUp === username}

--- a/client/src/views/Party/PlayAgain.jsx
+++ b/client/src/views/Party/PlayAgain.jsx
@@ -3,7 +3,7 @@ import React, { useState } from "react";
 import api from "../../utils/api";
 import { TextInput, Button, Checkbox } from "../../components";
 
-function PlayGame({ party, onPlayAgainClose }) {
+function PlayAgain({ party, onPlayAgainClose }) {
   const [keepSameTeams, setKeepSameTeams] = useState(false);
   const [teamsCount, setTeamsCount] = useState(party.settings.teamsCount);
   const [rotations, setRotations] = useState(party.settings.rotations);
@@ -100,4 +100,4 @@ function PlayGame({ party, onPlayAgainClose }) {
   );
 }
 
-export default PlayGame;
+export default PlayAgain;

--- a/server/src/tests/renameTeam.js
+++ b/server/src/tests/renameTeam.js
@@ -40,8 +40,7 @@ export const renameTeamTests = () => {
       teamIndex: 0,
       teamName: "JACK'S ALL STAR CAT PARADE",
     });
-
     const updatedPartyTeamName = updatedParty.games[0].teams[0].teamName;
-    expect(updatedPartyTeamName).toEqual(party.games[0].teams[0].teamName);
+    expect(updatedPartyTeamName).toEqual("FLYING FUCKS");
   });
 };


### PR DESCRIPTION
because there is no initial prompt asking for team names, instead offering a generated name and the option to rename at any time, Anders and I felt it was consistent to deny the same when opting to play again, letting the game choose two new generated team names that may be changed during the game.