### PR TITLE
Create a Mongo instance as a Docker container and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 
 .DS_Store
+
+# docker volumes
+/dockervolume

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ A companion app for playing [charades](https://en.wikipedia.org/wiki/Charades)
 
 To run this server, you have to connect to a MongoDB database. Your server will do this automatically once you've set the MONGO_URI environment variable.
 
-You have at least three options for getting a MONGO_URI for development:
+You have at least four options for getting a MONGO_URI for development:
 
+- (Super Easy) Run MongoDB in a Docker container using Docker Compose with the command `docker compose up`
 - (Easiest) Slack Andy and ask for your own database on his Mongo Atlas account, he'll send you a URI
 - (Easy) Sign up for Mongo Atlas yourself and create a databse for yourself, find the URI by going through the 'connect' flow
 - (Probably Easy) Run MongoDB on your machine locally, figure out your own URI
@@ -18,6 +19,12 @@ Set your `MONGO_URI` evironment variable in a `.env` file inside `server/`. If y
 
 ```
 MONGO_URI="mongodb+srv://<username>:<password>@cluster0-cusns.mongodb.net/<database>?retryWrites=true&w=majority"
+```
+
+If you're using Docker Compose, set you `MONGO_URI` to:
+
+```
+MONGO_URI="mongodb://admin:password@localhost:27017?retryWrites=true&w=majority"
 ```
 
 I put an example `.env` file in `.env.sample` feel free to `mv .env.sample .env` to get started.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  mongo:
+    image: mongo:5.0
+    restart: always
+    ports:
+      - 27017:27017
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=password
+    container_name: mongo
+    volumes:
+      - './dockervolume/mongodb:/data/db'

--- a/server/.env.sample
+++ b/server/.env.sample
@@ -1,0 +1,1 @@
+MONGO_URI="mongodb://admin:password@localhost:27017?retryWrites=true&w=majority"


### PR DESCRIPTION
This PR offers a MongoDB alternative in the form of a Docker container (using Docker Compose) to improve developer experience. Developers will be able to create and run a MongoDB instance by executing the `docker compose up` command.

This means the development environment can be created with three commands:
1. `docker compose up`
2. `cd client && nmp start`
3. `cd server && nmp start`

The pro to this update is speed. Developers can set up their environment with three commands. 
The con to this method is the loss of Atlas' UI, which might be helpful for beginners to visualize and analyze data.